### PR TITLE
Hot fix: update training volume to use latest data

### DIFF
--- a/targets/config_targets.R
+++ b/targets/config_targets.R
@@ -56,7 +56,7 @@ config_targets <- list(
     name = current_season_date_range,
     command = tibble(
       nowcast_date = seq(
-        from = ymd("2025-06-28"),
+        from = ymd("2025-07-05"),
         to = ymd("2026-04-18"),
         by = temporal_granularity
       )

--- a/targets/config_targets.R
+++ b/targets/config_targets.R
@@ -53,6 +53,16 @@ config_targets <- list(
     )
   ),
   tar_target(
+    name = current_season_date_range,
+    command = tibble(
+      nowcast_date = seq(
+        from = ymd("2025-06-28"),
+        to = ymd("2026-04-18"),
+        by = temporal_granularity
+      )
+    )
+  ),
+  tar_target(
     name = prev_season_date_range,
     command = tibble(
       nowcast_date = seq(

--- a/targets/training_volume_optimisation_targets.R
+++ b/targets/training_volume_optimisation_targets.R
@@ -75,7 +75,7 @@ training_volume_optimisation_targets <- list(
       scale_factor_tv_range,
       prop_delay_tv_range,
       pathogens,
-      nowcast_date_range
+      current_season_date_range
     ) |>
       mutate(tv_name = glue::glue("{pathogen}_{nowcast_date}_{scale_factor}_vol_{prop_delay}_prop_delay")), # nolint
     by = tv_name
@@ -116,14 +116,14 @@ training_volume_optimisation_targets <- list(
   tar_target(
     name = bar_chart_tv_latest,
     command = get_bar_chart_tv_scores(scores_tv_su_latest,
-      title = "2024-2025",
+      title = "2025-2026",
       fig_file_name = "bar_chart_training_volume_opt_latest"
     )
   ),
   tar_target(
     name = heatmap_tv_latest,
     command = get_plot_tv_scores(scores_tv_su_latest,
-      title = "2024-2025",
+      title = "2025-2026",
       fig_file_name = "heatmap_training_volume_latest"
     )
   ),


### PR DESCRIPTION
## Description

This PR updates the training volume optimisation using the latest data. 

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [ ] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added current season date range calculation spanning June 28, 2025 to April 18, 2026.

* **Updates**
  * Optimisation scenarios now use the new current season date range for generating forecasts.
  * Updated visualization titles from "2024-2025" to "2025-2026" to reflect the current season.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->