### PR TITLE
Issue 39: Changes to state nowcast comparison fig

### DIFF
--- a/R/state_scores_fig.R
+++ b/R/state_scores_fig.R
@@ -144,6 +144,7 @@ get_plot_nowcasts_vs_data <- function(nowcasts,
         color = model, group = nowcast_date_model
       )
     ) +
+    facet_wrap(~model, nrow = 2) +
     geom_line(
       data = nc,
       aes(
@@ -178,14 +179,14 @@ get_plot_nowcasts_vs_data <- function(nowcasts,
         x = end_of_week_reference_date, y = final_count,
         linetype = "Final evaluation data"
       ),
-      color = "red", linewidth = 1
+      color = "black", linewidth = 1
     ) +
     get_plot_theme(dates = TRUE) +
     scale_x_date(
       date_breaks = "1 month",
       date_labels = "%b %Y"
     ) +
-    facet_wrap(~pathogen_name) +
+    ggtitle(glue("{pathogen_name}")) +
     scale_color_manual(
       name = "Model",
       values = plot_comps$model_colors
@@ -206,9 +207,9 @@ get_plot_nowcasts_vs_data <- function(nowcasts,
       guide = guide_legend(
         override.aes = list(
           color = c(
-            "Final evaluation data" = "red",
+            "Final evaluation data" = "black",
             "Data as of nowcast date" = "gray",
-            "Date of nowcast" = "black"
+            "Date of nowcast" = "navy"
           ),
           linewidth = 1
         )
@@ -306,6 +307,7 @@ make_state_nowcast_comp_fig <- function(
 ) {
   fig_layout <- "
   AAAA
+  AAAA
   BCDE
   "
 
@@ -324,7 +326,7 @@ make_state_nowcast_comp_fig <- function(
       tag_levels = "A",
       tag_sep = "",
       theme = theme(
-        legend.position = "top",
+        legend.position = "right",
         legend.title = element_text(hjust = 0.5),
         plot.title = element_text(size = 20),
         legend.justification = "left",
@@ -352,8 +354,8 @@ make_state_nowcast_comp_fig <- function(
         fig_file_dir,
         glue("{fig_file_name}.png")
       ),
-      width = 20,
-      height = 12,
+      width = 22,
+      height = 16,
       dpi = 600
     )
   }

--- a/R/state_scores_fig.R
+++ b/R/state_scores_fig.R
@@ -161,7 +161,7 @@ get_plot_nowcasts_vs_data <- function(nowcasts,
         xintercept = nowcast_date,
         linetype = "Date of nowcast"
       ),
-      color = "black"
+      color = "navy"
     ) +
     geom_ribbon(
       data = nc,


### PR DESCRIPTION
## Description

This PR closes #39. Per our discussion, it removes the red line for the final evaluation data (replacing with black line) and adds two separate panels for each nowcast model in A, so they no longer overlay.


## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [X] I have added a news item linked to this PR.
- [X] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized nowcast comparison plots to facet by model for clearer visualization
  * Enhanced legend styling with updated color schemes and improved positioning
  * Increased PNG export resolution for state nowcast comparison figures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/epinowcast/baselinenowcast-us-paper/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->