### PR TITLE
Issue 48: Adjust analysis to nowcast on Wednesday

### DIFF
--- a/R/fit_bnc.R
+++ b/R/fit_bnc.R
@@ -102,6 +102,129 @@ fit_bnc_state <- function(all_data,
   return(nowcast_df)
 }
 
+#' Fit the baselinenowcast method to the state level data (all age groups)
+#'   from daily data
+#'
+#' @param all_data Data.frame of incident cases by reference date and report
+#'   date by day for multiple age groups and pathogens
+#' @param nowcast_date Date to produce the nowcast for.
+#' @param pathogen_i Pathogen to nowcast.
+#' @param eval_horizon Number of weeks to evaluation and save the nowcast.
+#' @param max_delay Maximum delay in weeks.
+#' @param quantiles_for_scoring Vector of quantiles to score.
+#' @param scale_factor Scale factor on maximum delay of the amount of data to
+#'   be used to train the baselinenowcast model.
+#' @param prop_delay Proportion of all training volume to use for delay
+#'   estimation
+#' @param draws Number of draws to save
+#' @importFrom baselinenowcast as_reporting_triangle baselinenowcast
+#' @importFrom lubridate weeks
+#' @importFrom dplyr distinct pull
+#'
+#' @returns Quantiled dataframe of nowcasts with initial and final case counts
+#'   alongside it.
+fit_bnc_state_from_daily <- function(all_data,
+                                     nowcast_date,
+                                     pathogen_i,
+                                     eval_horizon,
+                                     max_delay,
+                                     quantiles_for_scoring,
+                                     scale_factor = 3,
+                                     prop_delay = 0.5,
+                                     draws = 1000) {
+  # Convert delay from weekly to daily for noowcasting
+  max_delay_daily <- 7 * max_delay
+  this_data <- all_data |>
+    filter(
+      report_date <= nowcast_date,
+      pathogen == pathogen_i
+    ) |>
+    group_by(
+      reference_date,
+      report_date, delay
+    ) |>
+    summarise(count = sum(count, na.rm = TRUE)) |>
+    filter(delay <= max_delay_daily) |>
+    ungroup()
+
+  initial_data_summed <- this_data |>
+    filter(reference_date >=
+      max(reference_date) - weeks(eval_horizon)) |>
+    group_by(reference_date) |>
+    summarise(initial_count = sum(count))
+
+  final_data_summed <- all_data |>
+    filter(
+      pathogen == pathogen_i,
+      delay <= max_delay_daily, # Might want to change this so that it is still
+      # a rolling evaluation but its longer
+      reference_date <= nowcast_date
+    ) |>
+    group_by(reference_date) |>
+    summarise(final_count = sum(count, na.rm = TRUE)) |>
+    ungroup() |>
+    filter(reference_date >=
+      max(reference_date) - weeks(eval_horizon))
+  pathogen_name <- all_data |>
+    filter(pathogen == pathogen_i) |>
+    distinct(pathogen_name) |>
+    pull(pathogen_name)
+
+
+  # convert to a reporting triangle
+  rep_tri <- as_reporting_triangle(this_data,
+    max_delay = max_delay_daily,
+    delays_unit = "days",
+    reference_date = "reference_date",
+    report_date = "report_date"
+  )
+
+  # generate a nowcast using the default settings
+  nowcast_df <- baselinenowcast(rep_tri,
+    scale_factor = scale_factor,
+    prop_delay = prop_delay,
+    draws = draws
+  ) |>
+    left_join(initial_data_summed,
+      by = c("reference_date")
+    ) |>
+    left_join(final_data_summed,
+      by = c("reference_date")
+    ) |>
+    mutate(
+      # Convert to weekly
+      epiweek = epiweek(reference_date),
+      end_of_week_reference_date = ceiling_date(reference_date,
+        unit = "week",
+        week_start = 6
+      )
+    ) |>
+    group_by(end_of_week_reference_date, draw) |>
+    summarise(
+      pred_count = sum(pred_count),
+      initial_count = sum(initial_count),
+      final_count = sum(final_count)
+    ) |>
+    filter(end_of_week_reference_date < nowcast_date) |>
+    rename(reference_date = end_of_week_reference_date) |>
+    filter(reference_date >= max(reference_date) - weeks(eval_horizon)) |>
+    trajectories_to_quantiles(
+      quantiles = quantiles_for_scoring,
+      timepoint_cols = "reference_date",
+      value_col = "pred_count"
+    ) |>
+    mutate(
+      pathogen = pathogen_i,
+      pathogen_name = pathogen_name,
+      nowcast_date = nowcast_date,
+      age_group = "00+",
+      scale_factor = scale_factor,
+      prop_delay = prop_delay,
+      model_type = "base"
+    )
+  return(nowcast_df)
+}
+
 #' Fit the baselinenowcast method to age-groups
 #'
 #' @param all_data Data.frame of incident cases by reference date and report
@@ -258,6 +381,182 @@ fit_bnc_age_groups <- function(all_data,
     ) |>
     left_join(final_data_summed,
       by = c("reference_date", "age_group")
+    )
+  return(nowcasts_clean)
+}
+
+
+#' Fit the baselinenowcast method to age-groups
+#'
+#' @param all_data Data.frame of incident cases by reference date and report
+#'   date by day for multiple age groups and pathogens
+#' @param nowcast_date Date to produce the nowcast for.
+#' @param pathogen_i Pathogen to nowcast.
+#' @param eval_horizon Number of weeks to evaluation and save the nowcast.
+#' @param max_delay Maximum delay in weeks.
+#' @param quantiles_for_scoring Vector of quantiles to score.
+#' @param scale_factor Scale factor on maximum delay of the amount of data to
+#'   be used to train the baselinenowcast model.
+#' @param prop_delay Proportion of all training volume to use for delay
+#'   estimation
+#' @param draws Number of draws to save
+#' @importFrom baselinenowcast as_reporting_triangle baselinenowcast
+#'   get_delays_from_dates
+#' @importFrom lubridate weeks
+#' @importFrom dplyr distinct pull
+#'
+#' @returns Quantiled dataframe of nowcasts with initial and final case counts
+#'   alongside it.
+fit_bnc_age_groups_from_daily <- function(all_data,
+                                          nowcast_date,
+                                          pathogen_i,
+                                          model,
+                                          eval_horizon,
+                                          max_delay,
+                                          quantiles_for_scoring,
+                                          scale_factor = 3,
+                                          prop_delay = 0.5,
+                                          draws = 1000) {
+  # Convert delay from weekly to daily for noowcasting
+  max_delay_daily <- 7 * max_delay
+  this_data <- all_data |>
+    filter(
+      report_date <= nowcast_date,
+      pathogen == pathogen_i
+    ) |>
+    group_by(
+      reference_date,
+      report_date,
+      age_group,
+      delay
+    ) |>
+    summarise(count = sum(count, na.rm = TRUE)) |>
+    filter(delay <= max_delay_daily) |>
+    ungroup()
+
+  initial_data_summed <- this_data |>
+    filter(reference_date >=
+      max(reference_date) - weeks(eval_horizon)) |>
+    group_by(
+      reference_date,
+      age_group
+    ) |>
+    summarise(initial_count = sum(count, na.rm = TRUE))
+
+  final_data_summed <- all_data |>
+    filter(
+      pathogen == pathogen_i,
+      delay <= max_delay_daily, # Might want to change this so that it is still
+      # a rolling evaluation but its longer
+      reference_date <= nowcast_date
+    ) |>
+    group_by(
+      reference_date,
+      age_group
+    ) |>
+    summarise(final_count = sum(count, na.rm = TRUE)) |>
+    ungroup() |>
+    filter(reference_date >=
+      max(reference_date) - weeks(eval_horizon))
+  pathogen_name <- all_data |>
+    filter(pathogen == pathogen_i) |>
+    distinct(pathogen_name) |>
+    pull(pathogen_name)
+
+  # Get unique values
+  reference_dates <- unique(this_data$reference_date)
+  age_groups <- unique(this_data$age_group)
+
+  # Create all combinations
+  all_combos <- expand.grid(
+    reference_date = reference_dates,
+    age_group = age_groups,
+    delay = 0:max_delay_daily,
+    stringsAsFactors = FALSE
+  )
+
+  # Merge with actual data
+  all_combos <- merge(
+    all_combos,
+    this_data,
+    by = c("reference_date", "delay", "age_group"),
+    all.x = TRUE
+  )
+
+  # Fill in missing counts with 0
+  all_combos$count[is.na(all_combos$count)] <- 0
+
+  # For missing rows, calculate the maximum observable delay
+  # based on the latest report date in the dataset
+  max_report_date <- max(this_data$report_date)
+
+  all_combos$report_date <- all_combos$reference_date +
+    all_combos$delay * 7 # assuming weekly data
+
+  # You can then filter to only include combinations where
+  # report_date <= max_report_date to avoid impossible future combinations
+  all_combos <- all_combos[all_combos$report_date <= max_report_date, ]
+
+  # Generate a nowcast using the baselinenowcast.data.frame method (will need
+  # to change to as_rep_tri_df |> baselinenowcast when we update the package)
+  if (model == "baselinenowcast base") {
+    nowcast_df <- baselinenowcast(all_combos,
+      strata_cols = "age_group",
+      delays_unit = "days",
+      max_delay = max_delay_daily,
+      scale_factor = scale_factor,
+      prop_delay = prop_delay,
+      draws = draws
+    )
+  } else if (model == "baselinenowcast strata sharing") {
+    nowcast_df <- baselinenowcast(all_combos,
+      strata_cols = "age_group",
+      max_delay = max_delay_daily,
+      delays_unit = "days",
+      strata_sharing = c("delay", "uncertainty"),
+      scale_factor = scale_factor,
+      prop_delay = prop_delay,
+      draws = draws
+    )
+  }
+  nowcasts_clean <- nowcast_df |>
+    left_join(initial_data_summed,
+      by = c("reference_date", "age_group")
+    ) |>
+    left_join(final_data_summed,
+      by = c("reference_date", "age_group")
+    ) |>
+    mutate(
+      # Convert to weekly
+      epiweek = epiweek(reference_date),
+      end_of_week_reference_date = ceiling_date(reference_date,
+        unit = "week",
+        week_start = 6
+      )
+    ) |>
+    group_by(end_of_week_reference_date, draw, age_group) |>
+    summarise(
+      pred_count = sum(pred_count),
+      initial_count = sum(initial_count),
+      final_count = sum(final_count)
+    ) |>
+    # Exclude the nowcasts made in the partial week
+    filter(end_of_week_reference_date < nowcast_date) |>
+    rename(reference_date = end_of_week_reference_date) |>
+    filter(reference_date >= max(reference_date) - weeks(eval_horizon)) |>
+    trajectories_to_quantiles(
+      quantiles = quantiles_for_scoring,
+      timepoint_cols = "reference_date",
+      value_col = "pred_count",
+      id_cols = "age_group"
+    ) |>
+    mutate(
+      pathogen = pathogen_i,
+      model = model,
+      pathogen_name = pathogen_name,
+      nowcast_date = nowcast_date,
+      scale_factor = scale_factor,
+      prop_delay = prop_delay
     )
   return(nowcasts_clean)
 }

--- a/R/get_weekly_data.R
+++ b/R/get_weekly_data.R
@@ -67,6 +67,29 @@ get_weekly_data <- function(raw_data) {
   return(weekly_data)
 }
 
+#' Get properly formatted daily data with delays
+#'
+#' @param raw_data
+#'
+#' @returns formatted daily data
+get_daily_data <- function(raw_data) {
+  data <- raw_data |>
+    mutate(
+      delay = as.integer(difftime(report_date,
+        reference_date,
+        units = "days"
+      )),
+      delay_unit = "weeks",
+      pathogen_name = case_when(
+        pathogen == "bar" ~ "Broad Acute Respiratory Incidence",
+        pathogen == "flu" ~ "Influenza",
+        pathogen == "covid" ~ "COVID-19",
+        pathogen == "rsv" ~ "RSV"
+      )
+    )
+  return(data)
+}
+
 #' Clean data and add attributes like season and other indicators
 #'
 #' @param weekly_data Data.frame of cases by epiweek

--- a/_targets.R
+++ b/_targets.R
@@ -72,38 +72,38 @@ optimal_training_vol <- list(
   training_volume_optimisation_targets
 )
 
-## Produce nowcasts for each pathogen------------------------------------------
-nowcasts <- list(
-  state_nowcast_targets,
-  age_group_nowcast_targets
-)
+# ## Produce nowcasts for each pathogen------------------------------------------
+# nowcasts <- list(
+#   state_nowcast_targets
+#   #age_group_nowcast_targets
+# )
 ## Score nowcasts------------------------------------------------------------
-scores <- list(
-  score_targets
-)
-
-# Plots------------------------------------------------------------------------
-plots <- list(
-  #
-  # Delay characterisation plot targets
-  delay_plot_targets,
-
-  # Delay comparison plots
-  delay_comparison_targets,
-
-  # State-level nowcast evaluation figs
-  state_nowcast_eval_plot_targets,
-
-  # Age-group specific nowcast evaluation figs
-  ag_nowcast_eval_plot_targets
-)
+# scores <- list(
+#   score_targets
+# )
+#
+# # Plots------------------------------------------------------------------------
+# plots <- list(
+#   #
+#   # Delay characterisation plot targets
+#   delay_plot_targets,
+#
+#   # Delay comparison plots
+#   delay_comparison_targets,
+#
+#   # State-level nowcast evaluation figs
+#   state_nowcast_eval_plot_targets,
+#
+#   # Age-group specific nowcast evaluation figs
+#   ag_nowcast_eval_plot_targets
+# )
 
 list(
   config,
   set_up,
   load_and_clean_data,
-  optimal_training_vol,
-  nowcasts,
-  scores,
-  plots
+  optimal_training_vol
+  # nowcasts,
+  # scores,
+  # plots
 )

--- a/targets/config_targets.R
+++ b/targets/config_targets.R
@@ -46,8 +46,8 @@ config_targets <- list(
     name = nowcast_date_range,
     command = tibble(
       nowcast_date = seq(
-        from = ymd("2024-06-29"),
-        to = ymd("2025-06-28"),
+        from = ymd("2024-07-03"),
+        to = ymd("2025-07-02"),
         by = temporal_granularity
       )
     )
@@ -56,8 +56,8 @@ config_targets <- list(
     name = current_season_date_range,
     command = tibble(
       nowcast_date = seq(
-        from = ymd("2025-07-05"),
-        to = ymd("2026-04-18"),
+        from = ymd("2025-07-09"),
+        to = ymd("2026-04-22"),
         by = temporal_granularity
       )
     )
@@ -66,8 +66,8 @@ config_targets <- list(
     name = prev_season_date_range,
     command = tibble(
       nowcast_date = seq(
-        from = ymd("2023-07-01"),
-        to = ymd("2024-06-30"),
+        from = ymd("2023-07-05"),
+        to = ymd("2024-07-04"),
         by = temporal_granularity
       )
     )

--- a/targets/load_and_clean_data_targets.R
+++ b/targets/load_and_clean_data_targets.R
@@ -25,5 +25,9 @@ load_and_clean_data_targets <- list(
       prev_season_date_range = prev_season_date_range$nowcast_date,
       delay_est_date_range = delay_est_training_date_range
     )
+  ),
+  tar_target(
+    name = clean_daily_data,
+    command = get_daily_data(raw_data)
   )
 )

--- a/targets/training_volume_optimisation_targets.R
+++ b/targets/training_volume_optimisation_targets.R
@@ -15,8 +15,8 @@ training_volume_optimisation_targets <- list(
   # training volumes
   tar_target(
     name = state_nowcasts_bnc_tv,
-    command = fit_bnc_state(
-      all_data = clean_weekly_data,
+    command = fit_bnc_state_from_daily(
+      all_data = clean_daily_data,
       nowcast_date = tv_scenarios$nowcast_date,
       pathogen_i = tv_scenarios$pathogen,
       quantiles_for_scoring = quantiles_for_scoring,
@@ -84,8 +84,8 @@ training_volume_optimisation_targets <- list(
   # training volumes
   tar_target(
     name = state_nowcasts_bnc_tv_latest,
-    command = fit_bnc_state(
-      all_data = clean_weekly_data,
+    command = fit_bnc_state_from_daily(
+      all_data = clean_daily_data,
       nowcast_date = tv_scenarios_latest$nowcast_date,
       pathogen_i = tv_scenarios_latest$pathogen,
       quantiles_for_scoring = quantiles_for_scoring,


### PR DESCRIPTION
## Description

This PR closes #48. WIP. 

It does the following:
- creates two new functions which now ingest daily level data and produce weekly level nowcasts, truncating the output so that we nowcast through the previous Saturday
- modifies the training volume optimisation and calls to fit baselinenowcast to use the daily data. 

To do:
- edit the MADPH implementation code to compute and implement the multipliers 

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [ ] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
