### PR TITLE
Issue 52: add an analysis of weekly vs daily data as an input to baselinenowcast

### DIFF
--- a/R/plotting_style.R
+++ b/R/plotting_style.R
@@ -52,10 +52,12 @@ plot_components <- function() {
   )
   model_colors <- c(
     "baselinenowcast" = "purple4",
+    "baselinenowcast weekly" = "magenta3",
     "MADPH original" = "green4",
     "MADPH our implementation orig" = "red4",
     "MADPH method" = "orange2",
     "baselinenowcast strata sharing" = "turquoise4",
+    "baselinenowcast strata sharing weekly" = "skyblue3",
     "baselinenowcast base" = "purple4"
   )
   season_linetypes <- c(

--- a/R/plotting_style.R
+++ b/R/plotting_style.R
@@ -58,7 +58,8 @@ plot_components <- function() {
     "MADPH method" = "orange2",
     "baselinenowcast strata sharing" = "turquoise4",
     "baselinenowcast strata sharing weekly" = "skyblue3",
-    "baselinenowcast base" = "purple4"
+    "baselinenowcast base" = "purple4",
+    "baselinenowcast base weekly" = "magenta3"
   )
   season_linetypes <- c(
     "2023-2024" = "dashed",

--- a/targets/age_group_nowcast_targets.R
+++ b/targets/age_group_nowcast_targets.R
@@ -18,6 +18,29 @@ age_group_nowcast_targets <- list(
     ),
     pattern = map(scenarios)
   ),
+  tar_target(
+    name = age_group_nowcasts_bnc_weekly_raw,
+    command = fit_bnc_age_groups(
+      all_data = clean_weekly_data,
+      nowcast_date = scenarios$nowcast_date,
+      pathogen_i = scenarios$pathogen,
+      model = scenarios$model,
+      quantiles_for_scoring = quantiles_for_scoring,
+      max_delay = max_delay,
+      scale_factor = scenarios$scale_factor,
+      prop_delay = scenarios$prop_delay,
+      eval_horizon = eval_horizon,
+    ),
+    pattern = map(scenarios)
+  ),
+  tar_target(
+    name = age_group_nowcasts_bnc_weekly,
+    command = age_group_nowcasts_bnc_weekly_raw |>
+      mutate(model = ifelse(model == "baselinenowcast base", "baselinenowcast base weekly",
+        "baselinenowcast strata sharing weekly"
+      ))
+  ),
+
   # Load in MA age group nowcasts
   tar_target(
     name = raw_ag_nowcasts_madph,
@@ -35,10 +58,6 @@ age_group_nowcast_targets <- list(
     name = age_group_nowcasts_madph_named,
     command = age_group_nowcasts_madph |>
       mutate(model = "MADPH original")
-  ),
-  tar_target(
-    name = age_group_nowcasts_bnc_named,
-    command = age_group_nowcasts_bnc
   ),
   # Compute MADPH nowcasts----------------
   tar_target(
@@ -101,7 +120,8 @@ age_group_nowcast_targets <- list(
   tar_target(
     name = age_group_nowcasts,
     command = bind_rows(
-      age_group_nowcasts_bnc_named,
+      age_group_nowcasts_bnc,
+      age_group_nowcasts_bnc_weekly,
       nowcasts_madph_imp_revised_ag
     ) |>
       select(
@@ -113,7 +133,8 @@ age_group_nowcast_targets <- list(
   tar_target(
     name = age_group_nowcasts_alt,
     command = bind_rows(
-      age_group_nowcasts_bnc_named,
+      age_group_nowcasts_bnc,
+      age_group_nowcasts_bnc_weekly,
       age_group_nowcasts_madph_named
     ) |>
       select(
@@ -125,7 +146,8 @@ age_group_nowcast_targets <- list(
   tar_target(
     name = age_group_nowcasts_ma_method_comp,
     command = bind_rows(
-      age_group_nowcasts_bnc_named,
+      age_group_nowcasts_bnc,
+      age_group_nowcasts_bnc_weekly,
       age_group_nowcasts_madph_named,
       nowcasts_madph_imp_ag,
       nowcasts_madph_imp_revised_ag

--- a/targets/score_targets.R
+++ b/targets/score_targets.R
@@ -79,6 +79,7 @@ score_targets <- list(
         scale == "log",
         model %in% c(
           "baselinenowcast",
+          "baselinenowcast weekly",
           "MADPH method"
         )
       )
@@ -90,6 +91,7 @@ score_targets <- list(
         scale == "log",
         model %in% c(
           "baselinenowcast",
+          "baselinenowcast weekly",
           "MADPH original"
         )
       )
@@ -101,6 +103,7 @@ score_targets <- list(
         scale == "natural",
         model %in% c(
           "baselinenowcast",
+          "baselinenowcast weekly",
           "MADPH method"
         )
       )
@@ -123,6 +126,8 @@ score_targets <- list(
         model %in% c(
           "baselinenowcast base",
           "baselinenowcast strata sharing",
+          "baselinenowcast base weekly",
+          "baselinenowcast strata sharing weekly",
           "MADPH method"
         )
       )
@@ -135,6 +140,8 @@ score_targets <- list(
         model %in% c(
           "baselinenowcast base",
           "baselinenowcast strata sharing",
+          "baselinenowcast base weekly",
+          "baselinenowcast strata sharing weekly",
           "MADPH original"
         )
       )
@@ -147,6 +154,8 @@ score_targets <- list(
         model %in% c(
           "baselinenowcast base",
           "baselinenowcast strata sharing",
+          "baselinenowcast base weekly",
+          "baselinenowcast strata sharing weekly",
           "MADPH method"
         )
       )
@@ -167,6 +176,8 @@ score_targets <- list(
       filter(model %in% c(
         "baselinenowcast base",
         "baselinenowcast strata sharing",
+        "baselinenowcast base weekly",
+        "baselinenowcast strata sharing weekly",
         "MADPH method"
       ))
   ),
@@ -175,7 +186,8 @@ score_targets <- list(
     command = coverage_state_raw |>
       filter(model %in% c(
         "baselinenowcast",
-        "MADPH method"
+        "MADPH method",
+        "baselinenowcast weekly"
       ))
   )
 )

--- a/targets/state_nowcast_targets.R
+++ b/targets/state_nowcast_targets.R
@@ -1,6 +1,6 @@
 state_nowcast_targets <- list(
   # Get the state nowcasts as quantiles from both methods----------------------
-  # baselinenowcast default method
+  # baselinenowcast default method (daily data to weekly nowcasts)
   tar_target(
     name = state_nowcasts_bnc_full,
     command = fit_bnc_state_from_daily(
@@ -18,6 +18,29 @@ state_nowcast_targets <- list(
   tar_target(
     name = state_nowcasts_bnc,
     command = state_nowcasts_bnc_full |> distinct()
+  ),
+  # baselinenowcast usign weekly data
+  tar_target(
+    name = state_nowcasts_bnc_full_weekly,
+    command = fit_bnc(
+      all_data = clean_weekly_data,
+      nowcast_date = state_scenarios$nowcast_date,
+      pathogen_i = state_scenarios$pathogen,
+      quantiles_for_scoring = quantiles_for_scoring,
+      max_delay = max_delay,
+      eval_horizon = eval_horizon,
+      prop_delay = state_scenarios$prop_delay,
+      scale_factor = state_scenarios$scale_factor
+    ),
+    pattern = map(state_scenarios)
+  ),
+  tar_target(
+    name = state_nowcasts_bnc_weekly,
+    command = state_nowcasts_bnc_full_weekly |> distinct() |>
+      mutate(
+        model_type = "weekly",
+        model = "baselinenowcast weekly"
+      )
   ),
   ## Load in MA state-level nowcasts----------------------------------------
   tar_target(
@@ -108,7 +131,8 @@ state_nowcast_targets <- list(
     name = state_nowcasts,
     command = bind_rows(
       state_nowcasts_bnc_named,
-      state_nowcasts_madph_imp_revised
+      state_nowcasts_madph_imp_revised,
+      state_nowcasts_bnc_weekly
     ) |>
       select(
         reference_date, quantile_value, quantile_level,
@@ -134,7 +158,8 @@ state_nowcast_targets <- list(
       state_nowcasts_madph_named,
       state_nowcasts_madph_imp,
       state_nowcasts_madph_imp_revised,
-      state_nowcasts_bnc_named
+      state_nowcasts_bnc_named,
+      state_nowcasts_bnc_weekly
     ) |>
       select(
         reference_date, quantile_value, quantile_level,

--- a/targets/state_nowcast_targets.R
+++ b/targets/state_nowcast_targets.R
@@ -22,7 +22,7 @@ state_nowcast_targets <- list(
   # baselinenowcast usign weekly data
   tar_target(
     name = state_nowcasts_bnc_full_weekly,
-    command = fit_bnc(
+    command = fit_bnc_state(
       all_data = clean_weekly_data,
       nowcast_date = state_scenarios$nowcast_date,
       pathogen_i = state_scenarios$pathogen,


### PR DESCRIPTION
## Description

This PR closes #52. It adds to both the state-level and age-group specific nowcasts a comparison of the performance of the nowcasts using baselinenowcast either with daily data as an input (using the partial week's data up until Tuesday) or weekly data (using the data up until Saturday). In both cases, the nowcasts are evaluated on the weekly scale, but in the one instance daily nowcasts are produced and then aggregated to weekly, whereas in the other weekly nowcasts are used by default.

Motivation for this is to guide recommendations to public health practitioners who have daily data but want to produce weekly nowcasts. Initial assumption was that it would be better to use more granular data and then aggregate (especially because can make use of most recent data) but this might actually lead to over confident nowcasts, and is worth checking. 

I have updated main text figures and method comparison figures to make this comparison. 


## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [ ] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended baseline nowcasting system with weekly output variants for state and age-group nowcasts
  * Weekly variants integrated into composite nowcast collections and scoring/coverage metrics
  * Visualization system updated to display weekly baseline nowcast models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->