### PR TITLE
Issue 67: nowcasts produced from daily reference and daily reports then aggregated in main

### DIFF
--- a/R/plotting_style.R
+++ b/R/plotting_style.R
@@ -51,17 +51,17 @@ plot_components <- function() {
     "Unknown" = "gray"
   )
   model_colors <- c(
-    "baselinenowcast daily" = "salmon2",
+    "baselinenowcast daily" = "purple4",
     "baselinenowcast weekly" = "magenta3",
-    "baselinenowcast weekly reference daily reports" = "purple4",
+    "baselinenowcast weekly reference daily reports" = "salmon2",
     "baselinenowcast" = "purple4",
     "MADPH method" = "green4",
     "MADPH our implementation orig" = "red4",
     "MADPH revised" = "orange2",
     "baselinenowcast strata sharing" = "turquoise4",
     "baselinenowcast strata sharing weekly" = "skyblue3",
-    "baselinenowcast strata sharing weekly reference daily reports" = "turquoise4",
-    "baselinenowcast strata sharing daily" = "blue4",
+    "baselinenowcast strata sharing weekly reference daily reports" = "blue4",
+    "baselinenowcast strata sharing daily" = "turquoise4",
     "baselinenowcast base" = "purple4",
     "baselinenowcast base weekly" = "magenta3"
   )

--- a/R/state_scores_fig.R
+++ b/R/state_scores_fig.R
@@ -237,8 +237,7 @@ get_plot_nowcasts_vs_data <- function(nowcasts,
       )
     ) +
     xlab("") +
-    ylab(glue::glue("ED visits")) +
-    # ggtitle(glue::glue("Nowcasted ED visits due to {pathogen_name}")) +
+    ylab(glue("ED visits")) +
     guides(
       color = guide_legend(title.position = "top"),
       fill = guide_legend(title.position = "top"),

--- a/R/state_scores_fig.R
+++ b/R/state_scores_fig.R
@@ -554,7 +554,7 @@ get_bar_chart_coverage <- function(coverage,
       fill = guide_legend(
         title.position = "top",
         title.hjust = 0.5,
-        nrow = 1
+        nrow = 3
       )
     ) +
     ggtitle(title)

--- a/docs/supplement.qmd
+++ b/docs/supplement.qmd
@@ -21,16 +21,16 @@ output:
 
 Table S1. ICD10 diagnoses codes corresponding to each of the four syndrome definitions. For each of these pathogens, a single record of any of the listed ICD10 codes corresponds to a patient being characterised as a case of that particular syndrome. In all four syndromes, no subsequent diagnoses update can revert a patient from being classified as a case to a non-case.
 
-## Comparison of different methods of producing weekly nowcasts from daily data
+## S1. Text: Comparison of different methods of producing weekly nowcasts from daily data
 
-In the main text, the "baselinenowcast" and "baselinenowcast strata sharing" refers to the results obtained when we produced weekly nowcasts using data that was nowcasted in the form of weekly reference dates with daily reporting. In this case, we pre-processed the data from daily resolution to weekly resolution of reference dates with daily reporting e.g. a case assigned to a Monday reported on a Wednesday gets treated as being a Wednesday report for the week from Sunday to Saturday that contains the Monday. The original data was available at the daily resolution, and so additional options we considered were:
+In the main text, the "baselinenowcast" and "baselinenowcast strata sharing" refers to the results obtained when we produced daily nowcasts using daily reports, aggregated to weekly nowcasts in post-processing. Because our goal was to produce weekly nowcasts from data available at the daily resolution, additional options we also considered were:
 
--   daily reference dates with daily reporting, aggregated to weekly in post-processing
+-   weekly reference dates with daily reporting, with weekly aggregation of reference dates occurring in pre-processing. For example, a case assigned to a Monday reported on a Wednesday gets treated as a Wednesday report assigned to the week from Sunday to Saturday that contains the Monday.
 -   weekly reference dates with weekly reporting, where weekly aggregation occurred in pre-processing
 
-Since this is a commonly occurring situation, i.e. many public health departments have access to data at the daily level but report outputs weekly, we thought it would be useful to share the results of this comparison. There are different benefits and limitations of each approach, and we reasoned that the nowcasting weekly cases with daily reporting was the most principled method because it reflected the underlying reporting process well (e.g. a case from a day gets assigned to a week), the observation being modeled by the error model is the observation we are reporting (a weekly case count) and it allowed us to make use of partial data from reports that came in from Sunday to Tuesday of the week that the nowcast is produced (as we assumed it is produced on a Wednesday).
+Since this is a commonly occurring situation, i.e. many public health departments have access to data at the daily level but report outputs weekly, we thought it would be useful to share the results of this comparison. There are different benefits and limitations of each approach. Both the daily-daily nowcasting and the weekly reference dates-daily reporting allow us to make use of the partial data from reports that come in from Sunday to Tuesday of the week that the nowcast is produced. We ultimately chose to display the results from the daily-daily nowcasting aggregated to weekly in post-processing because it is the specification MADPH has recently adopted for their 2026-2027 baselinenowcast implementation.
 
-## Training volume optimisation details
+## S2. Text: Training volume optimisation details
 
 Using only data from the 2023-2024 season, we varied the total training volume as a function of the maximum delay and the proportion of the training volume used for delay estimation. Centering our analysis around the baselinenowcast package defaults, which use 3x the maximum delay for training volume and ½ of training volume used for delay estimation, we specified the model with all combinations of (1.5x, 3x, 4.5x the maximum delay for training volume and ⅓, ½, ⅔ of the training volume used for delay estimation, for a total of 9 different model specifications). We evaluated the performance of each specification using a rolling evaluation dataset of 10 weeks after the nowcast date.
 
@@ -124,6 +124,8 @@ Using only data from the 2023-2024 season, we varied the total training volume a
 
 ![Fig. S42 Comparison of the weighted interval score for different methods of producing weekly nowcasts from daily data for the age group nowcasts. Color indicates model, shading indicates WIS component.](../output/figs/fig4_ag_nowcast_alt.png)
 
-![Fig. SX Comparison of the weighted interval score for the original MAPDH method and the revised method. Color indicates model, shading indicates WIS component.](../output/figs/fig4_ag_nowcast_comp.png)
-
 ![Fig. S43 Comparison of the 95% interval coverage of the different methods of producing weekly nowcasts from daily data for the age group nowcasts. Color indicates model, dashed horizontal line indicates nominal interval coverage](../output/figs/supp/ag_coverage_alt.png)
+
+![Fig. SX Comparison of the weighted interval score for the original MAPDH method and the revised method for age group specific nowcasts. Color indicates model, shading indicates WIS component.](../output/figs/fig4_ag_nowcast_comp.png)
+
+![Fig. SX Comparison of the weighted interval score for the original MAPDH method and the revised method. Color indicates model, shading indicates WIS component.](../output/figs/fig3_state_nowcast_comp.png)

--- a/docs/supplement.qmd
+++ b/docs/supplement.qmd
@@ -13,7 +13,7 @@ output:
 ## Syndrome definitions
 
 | Syndrome | ICD10 Diagnoses codes |
-|:-----------------------------------|:-----------------------------------|
+|:---|:---|
 | Broad Acute Respiratory Incidence (BAR) | "A22.1", "A221", "A37", "A48.1", "A481", "B25.0", "B250", "B34.2", "B34.9", "B342", "B349", "B44.0", "B44.9", "B440", "B449", "B44.81", "B4481", "B97.2", "B97.4", "B972", "B974", "J00", "J01", "J02", "J03", "J04", "J05", "J06", "J09", "J10", "J11", "J12", "J13", "J14", "J15", "J16", "J17", "J18", "J20", "J21", "J22", "J39.8", "J398", "J40", "J47.9", "J479", "J80", "J85.1", "J851", "J95.821", "J95821", "J96.0", "J96.00", "J9600", "J96.01", "J9601", "J96.02", "J9602", "J96.2", "J960", "J962", "J96.20", "J9620", "J96.21", "J9621", "J9622", "J96.22", "J96.91", "J9691", "J98.8", "J988", "R05", "R06.03", "R0603", "R09.02", "R0902", "R09.2", "R092", "R43.0", "R43.1", "R43.2", "R430", "R431", "R432", "U07.1", "U07.2", "U071", "U072", "022.1", "0221", "034.0", "0340", "041.5", "0415", "041.81", "04181", "079.1", "079.2", "079.3", "079.6", "0791", "0792", "0793", "0796", "079.82", "079.89", "07982", "07989", "079.99", "07999", "117.3", "1173", "460", "461", "462", "463", "464", "465", "466", "461.", "461", "461.", "464.", "465.", "466.", "461", "464", "465", "466", "478.9", "4789", "480.", "482.", "483.", "484.", "487.", "488.", "480", "481", "482", "483", "484", "485", "486", "487", "488", "490", "494.1", "4941", "517.1", "5171", "518.51", "518.53", "51851", "51853", "518.6", "5186", "518.81", "518.82", "518.84", "51881", "51882", "51884", "519.8", "5198", "073.0", "0730", "781.1", "7811", "786.2", "7862", "799.02", "79902", "799.1", "7991", "033", "033.", "033", "780.60", "78060" |
 | COVID-19 | "J12.82","J1282","U07.1","U071","840539006","840544004","840533007" |
 | Influenza | "J09","J10","J11","487","4870","487.1","4871","487.8","4878","488.01","48801","488.09","48809","488.11","48811","488.19","48819","488.81","48881","488.89","48889","442696006","442438000","6142004","195878008" |
@@ -70,62 +70,62 @@ Using only data from the 2023-2024 season, we varied the total training volume a
 
 ![Fig. S16 Comparison of the 95% interval coverage of the different methods of producing weekly nowcasts from daily data for the state-level (combined across age group) nowcasts. Color indicates model, dashed horizontal line indicates nominal interval coverage](../output/figs/supp/state_coverage_alt.png)
 
+![Fig. S17 Comparison of the weighted interval score for the original MAPDH method and the revised method. Color indicates model, shading indicates WIS component.](../output/figs/fig3_state_nowcast_comp.png)
+
 ### Additional scoring results for age-group specific nowcasts
 
-![Fig. S17 Trend accuracy assessment aggregated across all age groups. Color indicates model, faceted by pathogen.](../output/figs/supp/ag_trend_accuracy_agg.png)
+![Fig. S18 Trend accuracy assessment aggregated across all age groups. Color indicates model, faceted by pathogen.](../output/figs/supp/ag_trend_accuracy_agg.png)
 
-![Fig. S18 Trend accuracy assessment by age group. Color indicates model, rows indicate pathogens, columns indicate age groups.](../output/figs/supp/ag_trend_accuracy.png)
+![Fig. S19 Trend accuracy assessment by age group. Color indicates model, rows indicate pathogens, columns indicate age groups.](../output/figs/supp/ag_trend_accuracy.png)
 
-![Fig. S19 95% interval coverage for age group specific nowasts. Colors indicate model, horizontal dashed line indicates the nominal interval coverage, e.g. for a perfectly well-calibrated nowcast we would expect 95% of the observations to fall within the 95% prediction interval.](../output/figs/supp/ag_coverage.png)
+![Fig. S20 95% interval coverage for age group specific nowasts. Colors indicate model, horizontal dashed line indicates the nominal interval coverage, e.g. for a perfectly well-calibrated nowcast we would expect 95% of the observations to fall within the 95% prediction interval.](../output/figs/supp/ag_coverage.png)
 
-![Fig. S20 Weighted interval score (WIS) for RSV for each age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/rsv_by_ag.png)
+![Fig. S21 Weighted interval score (WIS) for RSV for each age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/rsv_by_ag.png)
 
-![Fig. S21 Weighted interval score (WIS) for Broad Acute Respiratory Incidence for each age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/bar_by_ag.png)
+![Fig. S22 Weighted interval score (WIS) for Broad Acute Respiratory Incidence for each age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/bar_by_ag.png)
 
-![Fig. S22 Weighted interval score (WIS) for Influenza for each age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/flu_by_ag.png)
+![Fig. S23 Weighted interval score (WIS) for Influenza for each age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/flu_by_ag.png)
 
-![Fig. S23 Weighted interval score (WIS) for COVID-19 for each age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/covid_by_ag.png)
+![Fig. S24 Weighted interval score (WIS) for COVID-19 for each age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/covid_by_ag.png)
 
-![Fig. S24 Zero-week horizon nowcasts for each model for Broad Acute Respiratory incidence in the 00-04 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/bar_horizon_0_00_04.png)
+![Fig. S25 Zero-week horizon nowcasts for each model for Broad Acute Respiratory incidence in the 00-04 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/bar_horizon_0_00_04.png)
 
-![Fig. S25 Zero-week horizon nowcasts for each model for Broad Acute Respiratory incidence in the 05-17 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/bar_horizon_0_05_17.png)
+![Fig. S26 Zero-week horizon nowcasts for each model for Broad Acute Respiratory incidence in the 05-17 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/bar_horizon_0_05_17.png)
 
-![Fig. S26 Zero-week horizon nowcasts for each model for Broad Acute Respiratory incidence in the 18-44 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/bar_horizon_0_18_44.png)
+![Fig. S27 Zero-week horizon nowcasts for each model for Broad Acute Respiratory incidence in the 18-44 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/bar_horizon_0_18_44.png)
 
-![Fig. S27 Zero-week horizon nowcasts for each model for Broad Acute Respiratory incidence in the 45-64 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/bar_horizon_0_45_64.png)
+![Fig. S28 Zero-week horizon nowcasts for each model for Broad Acute Respiratory incidence in the 45-64 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/bar_horizon_0_45_64.png)
 
-![Fig. S28 Zero-week horizon nowcasts for each model for Broad Acute Respiratory incidence in the 65+ age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/bar_horizon_0_65plus.png)
+![Fig. S29 Zero-week horizon nowcasts for each model for Broad Acute Respiratory incidence in the 65+ age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/bar_horizon_0_65plus.png)
 
-![Fig. S29 Zero-week horizon nowcasts for each model for COVID-19 in the 00-04 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/covid_horizon_0_00_04.png)
+![Fig. S30 Zero-week horizon nowcasts for each model for COVID-19 in the 00-04 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/covid_horizon_0_00_04.png)
 
-![Fig. S30 Zero-week horizon nowcasts for each model for COVID-19 in the 05-17 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/covid_horizon_0_05_17.png)
+![Fig. S31 Zero-week horizon nowcasts for each model for COVID-19 in the 05-17 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/covid_horizon_0_05_17.png)
 
-![Fig. S31 Zero-week horizon nowcasts for each model for COVID-19 in the 18-44 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/covid_horizon_0_18_44.png)
+![Fig. S32 Zero-week horizon nowcasts for each model for COVID-19 in the 18-44 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/covid_horizon_0_18_44.png)
 
-![Fig. S32 Zero-week horizon nowcasts for each model for COVID-19 in the 45-64 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/covid_horizon_0_45_64.png)
+![Fig. S33 Zero-week horizon nowcasts for each model for COVID-19 in the 45-64 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/covid_horizon_0_45_64.png)
 
-![Fig. S33 Zero-week horizon nowcasts for each model for COVID-19 in the 65+ age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/covid_horizon_0_65plus.png)
+![Fig. S34 Zero-week horizon nowcasts for each model for COVID-19 in the 65+ age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/covid_horizon_0_65plus.png)
 
-![Fig. S34 Zero-week horizon nowcasts for each model for influenza in the 00-04 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/flu_horizon_0_00_04.png)
+![Fig. S35 Zero-week horizon nowcasts for each model for influenza in the 00-04 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/flu_horizon_0_00_04.png)
 
-![Fig. S35 Zero-week horizon nowcasts for each model for influenza in the 05-17 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/flu_horizon_0_05_17.png)
+![Fig. S36 Zero-week horizon nowcasts for each model for influenza in the 05-17 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/flu_horizon_0_05_17.png)
 
-![Fig. S36 Zero-week horizon nowcasts for each model for influenza in the 18-44 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/flu_horizon_0_18_44.png)
+![Fig. S37 Zero-week horizon nowcasts for each model for influenza in the 18-44 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/flu_horizon_0_18_44.png)
 
-![Fig. S37 Zero-week horizon nowcasts for each model for influenza in the 45-64 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/flu_horizon_0_45_64.png)
+![Fig. S38 Zero-week horizon nowcasts for each model for influenza in the 45-64 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/flu_horizon_0_45_64.png)
 
-![Fig. S38 Zero-week horizon nowcasts for each model for influenza in the 65+ age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/flu_horizon_0_65plus.png)
+![Fig. S39 Zero-week horizon nowcasts for each model for influenza in the 65+ age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/flu_horizon_0_65plus.png)
 
-![Fig. S39 Zero-week horizon nowcasts for each model for RSV in the 05-17 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/rsv_horizon_0_05_17.png)
+![Fig. S40 Zero-week horizon nowcasts for each model for RSV in the 05-17 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/rsv_horizon_0_05_17.png)
 
-![Fig. S40 Zero-week horizon nowcasts for each model for RSV in the 18-44 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/rsv_horizon_0_18_44.png)
+![Fig. S41 Zero-week horizon nowcasts for each model for RSV in the 18-44 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/rsv_horizon_0_18_44.png)
 
-![Fig. S41 Zero-week horizon nowcasts for each model for RSV in the 45-64 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/rsv_horizon_0_45_64.png)
+![Fig. S42 Zero-week horizon nowcasts for each model for RSV in the 45-64 age group. Color indicates model, shading indicates WIS component.](../output/figs/supp/rsv_horizon_0_45_64.png)
 
-![Fig. S42 Comparison of the weighted interval score for different methods of producing weekly nowcasts from daily data for the age group nowcasts. Color indicates model, shading indicates WIS component.](../output/figs/fig4_ag_nowcast_alt.png)
+![Fig. S43 Comparison of the weighted interval score for different methods of producing weekly nowcasts from daily data for the age group nowcasts. Color indicates model, shading indicates WIS component.](../output/figs/fig4_ag_nowcast_alt.png)
 
-![Fig. S43 Comparison of the 95% interval coverage of the different methods of producing weekly nowcasts from daily data for the age group nowcasts. Color indicates model, dashed horizontal line indicates nominal interval coverage](../output/figs/supp/ag_coverage_alt.png)
+![Fig. S44 Comparison of the 95% interval coverage of the different methods of producing weekly nowcasts from daily data for the age group nowcasts. Color indicates model, dashed horizontal line indicates nominal interval coverage](../output/figs/supp/ag_coverage_alt.png)
 
-![Fig. SX Comparison of the weighted interval score for the original MAPDH method and the revised method for age group specific nowcasts. Color indicates model, shading indicates WIS component.](../output/figs/fig4_ag_nowcast_comp.png)
-
-![Fig. SX Comparison of the weighted interval score for the original MAPDH method and the revised method. Color indicates model, shading indicates WIS component.](../output/figs/fig3_state_nowcast_comp.png)
+![Fig. S45 Comparison of the weighted interval score for the original MAPDH method and the revised method for age group specific nowcasts. Color indicates model, shading indicates WIS component.](../output/figs/fig4_ag_nowcast_comp.png)

--- a/docs/supplement.qmd
+++ b/docs/supplement.qmd
@@ -13,7 +13,7 @@ output:
 ## Syndrome definitions
 
 | Syndrome | ICD10 Diagnoses codes |
-|:---|:---|
+|:-----------------------------------|:-----------------------------------|
 | Broad Acute Respiratory Incidence (BAR) | "A22.1", "A221", "A37", "A48.1", "A481", "B25.0", "B250", "B34.2", "B34.9", "B342", "B349", "B44.0", "B44.9", "B440", "B449", "B44.81", "B4481", "B97.2", "B97.4", "B972", "B974", "J00", "J01", "J02", "J03", "J04", "J05", "J06", "J09", "J10", "J11", "J12", "J13", "J14", "J15", "J16", "J17", "J18", "J20", "J21", "J22", "J39.8", "J398", "J40", "J47.9", "J479", "J80", "J85.1", "J851", "J95.821", "J95821", "J96.0", "J96.00", "J9600", "J96.01", "J9601", "J96.02", "J9602", "J96.2", "J960", "J962", "J96.20", "J9620", "J96.21", "J9621", "J9622", "J96.22", "J96.91", "J9691", "J98.8", "J988", "R05", "R06.03", "R0603", "R09.02", "R0902", "R09.2", "R092", "R43.0", "R43.1", "R43.2", "R430", "R431", "R432", "U07.1", "U07.2", "U071", "U072", "022.1", "0221", "034.0", "0340", "041.5", "0415", "041.81", "04181", "079.1", "079.2", "079.3", "079.6", "0791", "0792", "0793", "0796", "079.82", "079.89", "07982", "07989", "079.99", "07999", "117.3", "1173", "460", "461", "462", "463", "464", "465", "466", "461.", "461", "461.", "464.", "465.", "466.", "461", "464", "465", "466", "478.9", "4789", "480.", "482.", "483.", "484.", "487.", "488.", "480", "481", "482", "483", "484", "485", "486", "487", "488", "490", "494.1", "4941", "517.1", "5171", "518.51", "518.53", "51851", "51853", "518.6", "5186", "518.81", "518.82", "518.84", "51881", "51882", "51884", "519.8", "5198", "073.0", "0730", "781.1", "7811", "786.2", "7862", "799.02", "79902", "799.1", "7991", "033", "033.", "033", "780.60", "78060" |
 | COVID-19 | "J12.82","J1282","U07.1","U071","840539006","840544004","840533007" |
 | Influenza | "J09","J10","J11","487","4870","487.1","4871","487.8","4878","488.01","48801","488.09","48809","488.11","48811","488.19","48819","488.81","48881","488.89","48889","442696006","442438000","6142004","195878008" |
@@ -23,7 +23,7 @@ Table S1. ICD10 diagnoses codes corresponding to each of the four syndrome defin
 
 ## S1. Text: Comparison of different methods of producing weekly nowcasts from daily data
 
-In the main text, the "baselinenowcast" and "baselinenowcast strata sharing" refers to the results obtained when we produced daily nowcasts using daily reports, aggregated to weekly nowcasts in post-processing. Because our goal was to produce weekly nowcasts from data available at the daily resolution, additional options we also considered were:
+In the main text, the "baselinenowcast" and "baselinenowcast strata sharing" refer to the results obtained when we produced daily nowcasts using daily reports, aggregated to weekly nowcasts in post-processing. Because our goal was to produce weekly nowcasts from data available at the daily resolution, additional options we also considered were:
 
 -   weekly reference dates with daily reporting, with weekly aggregation of reference dates occurring in pre-processing. For example, a case assigned to a Monday reported on a Wednesday gets treated as a Wednesday report assigned to the week from Sunday to Saturday that contains the Monday.
 -   weekly reference dates with weekly reporting, where weekly aggregation occurred in pre-processing
@@ -44,7 +44,7 @@ Using only data from the 2023-2024 season, we varied the total training volume a
 
 ![Fig. S4 Comparison of delays over time and total ED visits over time for the 2023-2024 and 2024-2025 season. A. Mean reporting delay in days over time by age group for each pathogen and for each season. Colors indicate age group. Linetype indicates season. B. Total ED visits over time, linetype indicates season](../output/figs/compare_seasons.png)
 
-![Fig. S5 Mean delay over time compared to mean delay used by the MADPH nowcasts (orange line) for each pathogen](../output/figs/supp/delays_over_time_vs_MA_delay.png)
+![Fig. S5 Mean delay over time for each pathogen. ](../output/figs/supp/delays_over_time_vs_MA_delay.png)
 
 ![Fig. S6 Between and within season variability in mean delay. A. Variation in delay between seasons for each pathogen (rows). Points indicate the mean delay, bars indicates 1 standard deviation from the mean delay, colors indicate season. B.Variation in delay across the season for each pathogen (rows). Color indicates season.](../output/figs/supp/delay_within_between_season_comparison.png)
 
@@ -70,7 +70,7 @@ Using only data from the 2023-2024 season, we varied the total training volume a
 
 ![Fig. S16 Comparison of the 95% interval coverage of the different methods of producing weekly nowcasts from daily data for the state-level (combined across age group) nowcasts. Color indicates model, dashed horizontal line indicates nominal interval coverage](../output/figs/supp/state_coverage_alt.png)
 
-![Fig. S17 Comparison of the weighted interval score for the original MAPDH method and the revised method. Color indicates model, shading indicates WIS component.](../output/figs/fig3_state_nowcast_comp.png)
+![Fig. S17 Comparison of the weighted interval score for the original MADPH method and the revised method. Color indicates model, shading indicates WIS component.](../output/figs/fig3_state_nowcast_comp.png)
 
 ### Additional scoring results for age-group specific nowcasts
 
@@ -128,4 +128,4 @@ Using only data from the 2023-2024 season, we varied the total training volume a
 
 ![Fig. S44 Comparison of the 95% interval coverage of the different methods of producing weekly nowcasts from daily data for the age group nowcasts. Color indicates model, dashed horizontal line indicates nominal interval coverage](../output/figs/supp/ag_coverage_alt.png)
 
-![Fig. S45 Comparison of the weighted interval score for the original MAPDH method and the revised method for age group specific nowcasts. Color indicates model, shading indicates WIS component.](../output/figs/fig4_ag_nowcast_comp.png)
+![Fig. S45 Comparison of the weighted interval score for the original MADPH method and the revised method for age group specific nowcasts. Color indicates model, shading indicates WIS component.](../output/figs/fig4_ag_nowcast_comp.png)

--- a/targets/age_group_nowcast_targets.R
+++ b/targets/age_group_nowcast_targets.R
@@ -58,15 +58,15 @@ age_group_nowcast_targets <- list(
   tar_target(
     name = age_group_nowcasts_bnc_daily,
     command = age_group_nowcasts_bnc |>
-      mutate(model = ifelse(model == "baselinenowcast base", "baselinenowcast daily",
-        "baselinenowcast strata sharing daily"
+      mutate(model = ifelse(model == "baselinenowcast base", "baselinenowcast",
+        "baselinenowcast strata sharing"
       ))
   ),
   tar_target(
     name = age_group_nowcasts_bnc_dw,
     command = age_group_nowcasts_bnc_dw_raw |>
-      mutate(model = ifelse(model == "baselinenowcast base", "baselinenowcast",
-        "baselinenowcast strata sharing"
+      mutate(model = ifelse(model == "baselinenowcast base", "baselinenowcast weekly reference daily reports",
+        "baselinenowcast strata sharing weekly reference daily reports"
       ))
   ),
 
@@ -149,7 +149,7 @@ age_group_nowcast_targets <- list(
   tar_target(
     name = age_group_nowcasts,
     command = bind_rows(
-      age_group_nowcasts_bnc_dw,
+      age_group_nowcasts_bnc_daily,
       age_group_nowcasts_madph_named
     ) |>
       select(
@@ -161,7 +161,7 @@ age_group_nowcast_targets <- list(
   tar_target(
     name = age_group_nowcasts2,
     command = bind_rows(
-      age_group_nowcasts_bnc_dw,
+      age_group_nowcasts_bnc_daily,
       nowcasts_madph_imp_revised_ag,
     ) |>
       select(
@@ -198,8 +198,8 @@ age_group_nowcast_targets <- list(
         pathogen_name
       ) |>
       mutate(model = case_when(
-        model == "baselinenowcast" ~ "baselinenowcast weekly reference daily reports",
-        model == "baselinenowcast strata sharing" ~ "baselinenowcast strata sharing weekly reference daily reports",
+        model == "baselinenowcast" ~ "baselinenowcast daily",
+        model == "baselinenowcast strata sharing" ~ "baselinenowcast strata sharing daily",
         TRUE ~ model
       ))
   ),
@@ -207,7 +207,7 @@ age_group_nowcast_targets <- list(
     name = age_group_nowcasts_ma_method_comp,
     command = bind_rows(
       age_group_nowcasts_madph_named,
-      nowcasts_madph_imp_ag,
+      age_group_nowcasts_bnc_daily,
       nowcasts_madph_imp_revised_ag
     ) |>
       select(

--- a/targets/score_targets.R
+++ b/targets/score_targets.R
@@ -100,13 +100,13 @@ score_targets <- list(
       filter(
         scale == "log",
         model %in% c(
-          "baselinenowcast daily",
+          "baselinenowcast",
           "baselinenowcast weekly",
-          "baselinenowcast"
+          "baselinenowcast weekly reference daily reports"
         )
       ) |>
       mutate(model = ifelse(model == "baselinenowcast",
-        "baselinenowcast weekly reference daily reports",
+        "baselinenowcast daily",
         model
       ))
   ),
@@ -173,17 +173,17 @@ score_targets <- list(
       filter(
         scale == "log",
         model %in% c(
-          "baselinenowcast daily",
-          "baselinenowcast strata sharing daily",
+          "baselinenowcast",
+          "baselinenowcast strata sharing",
           "baselinenowcast weekly",
           "baselinenowcast strata sharing weekly",
-          "baselinenowcast",
-          "baselinenowcast strata sharing"
+          "baselinenowcast weekly reference daily reports",
+          "baselinenowcast strata sharing weekly reference daily reports"
         )
       ) |>
       mutate(model = case_when(
-        model == "baselinenowcast" ~ "baselinenowcast weekly reference daily reports",
-        model == "baselinenowcast strata sharing" ~ "baselinenowcast strata sharing weekly reference daily reports",
+        model == "baselinenowcast" ~ "baselinenowcast daily",
+        model == "baselinenowcast strata sharing" ~ "baselinenowcast strata sharing daily",
         TRUE ~ model
       ))
   ),
@@ -234,16 +234,16 @@ score_targets <- list(
     name = coverage_ag_alt,
     command = coverage_ag_raw |>
       filter(model %in% c(
-        "baselinenowcast daily",
-        "baselinenowcast daily strata sharing",
+        "baselinenowcast weekly reference daily reports",
+        "baselinenowcast strata sharing weekly reference daily reports",
         "baselinenowcast weekly",
         "baselinenowcast strata sharing weekly",
         "baselinenowcast",
         "baselinenowcast strata sharing"
       )) |>
       mutate(model = case_when(
-        model == "baselinenowcast" ~ "baselinenowcast weekly reference daily reports",
-        model == "baselinenowcast strata sharing" ~ "baselinenowcast strata sharing weekly reference daily reports",
+        model == "baselinenowcast" ~ "baselinenowcast daily",
+        model == "baselinenowcast strata sharing" ~ "baselinenowcast strata sharing daily",
         TRUE ~ model
       ))
   ),
@@ -260,13 +260,13 @@ score_targets <- list(
     command = coverage_state_raw |>
       filter(
         model %in% c(
-          "baselinenowcast daily",
+          "baselinenowcast weekly reference daily reports",
           "baselinenowcast weekly",
           "baselinenowcast"
         )
       ) |>
       mutate(model = ifelse(model == "baselinenowcast",
-        "baselinenowcast weekly reference daily reports",
+        "baselinenowcast daily",
         model
       ))
   )

--- a/targets/score_targets.R
+++ b/targets/score_targets.R
@@ -194,6 +194,7 @@ score_targets <- list(
         scale == "log",
         model %in% c(
           "baselinenowcast",
+          "baselinenowcast strata sharing",
           "MADPH method",
           "MADPH revised"
         )

--- a/targets/state_nowcast_eval_plot_targets.R
+++ b/targets/state_nowcast_eval_plot_targets.R
@@ -445,7 +445,6 @@ state_nowcast_eval_plot_targets <- list(
         filter(model %in%
           c(
             "MADPH method",
-            "MADPH revised",
             "baselinenowcast"
           )) |>
         mutate(age_group = "00+"),
@@ -462,7 +461,6 @@ state_nowcast_eval_plot_targets <- list(
         filter(model %in%
           c(
             "MADPH method",
-            "MADPH revised",
             "baselinenowcast"
           )) |>
         mutate(age_group = "00+"),
@@ -479,7 +477,6 @@ state_nowcast_eval_plot_targets <- list(
         filter(model %in%
           c(
             "MADPH method",
-            "MADPH revised",
             "baselinenowcast"
           )) |>
         mutate(age_group = "00+"),
@@ -496,7 +493,6 @@ state_nowcast_eval_plot_targets <- list(
         filter(model %in%
           c(
             "MADPH method",
-            "MADPH revised",
             "baselinenowcast"
           )) |>
         mutate(age_group = "00+"),
@@ -513,7 +509,6 @@ state_nowcast_eval_plot_targets <- list(
         filter(model %in%
           c(
             "MADPH method",
-            "MADPH revised",
             "baselinenowcast"
           )) |>
         mutate(age_group = "00+"),

--- a/targets/state_nowcast_targets.R
+++ b/targets/state_nowcast_targets.R
@@ -20,7 +20,7 @@ state_nowcast_targets <- list(
     name = state_nowcasts_bnc_named,
     command = state_nowcasts_bnc_full |> distinct() |>
       mutate(
-        model = "baselinenowcast daily"
+        model = "baselinenowcast"
       )
   ),
   tar_target(
@@ -43,7 +43,7 @@ state_nowcast_targets <- list(
     command = state_nowcasts_bnc_full_dw |> distinct() |>
       mutate(
         model_type = "weekly reference daily reports",
-        model = "baselinenowcast"
+        model = "baselinenowcast weekly reference daily reports"
       )
   ),
   # baselinenowcast using weekly data
@@ -154,7 +154,7 @@ state_nowcast_targets <- list(
     name = state_nowcasts,
     command = bind_rows(
       state_nowcasts_madph_named,
-      state_nowcasts_bnc_dw
+      state_nowcasts_bnc_named
     ) |>
       select(
         reference_date, quantile_value, quantile_level,
@@ -166,7 +166,7 @@ state_nowcast_targets <- list(
     name = state_nowcasts2,
     command = bind_rows(
       state_nowcasts_madph_imp_revised,
-      state_nowcasts_bnc_dw
+      state_nowcasts_bnc_named
     ) |>
       select(
         reference_date, quantile_value, quantile_level,
@@ -202,7 +202,7 @@ state_nowcast_targets <- list(
         pathogen_name
       ) |>
       mutate(model = ifelse(model == "baselinenowcast",
-        "baselinenowcast weekly reference daily reports",
+        "baselinenowcast daily",
         model
       ))
   ),
@@ -211,7 +211,7 @@ state_nowcast_targets <- list(
     command = bind_rows(
       state_nowcasts_madph_named,
       state_nowcasts_madph_imp_revised,
-      state_nowcasts_bnc_dw
+      state_nowcasts_bnc_named
     ) |>
       select(
         reference_date, quantile_value, quantile_level,


### PR DESCRIPTION
## Description

This PR closes #67. Per our discussion with MADPH, we have moved the daily-daily nowcast implementation to the main text results, for consistency with what they have recently adopted.

Scope creep: add in the MADPH method revision to the supplement and update supplemental figures and corresponding references accordingly.

## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [X] I have added a news item linked to this PR.
- [X] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer distinctions between daily, weekly, and weekly-reference nowcast results.
  - Expanded age-group comparisons to include strata-sharing baseline models.

- **Bug Fixes**
  - Corrected model color assignments and updated chart labeling.
  - Improved coverage chart readability with a three-row legend.
  - Refined nowcast evaluation plots by removing outdated model results.

- **Documentation**
  - Clarified supplementary documentation for nowcast configurations, aggregation timing, training, and figure references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->